### PR TITLE
allow nested params in cookies

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -1,0 +1,14 @@
+Metrics/CyclomaticComplexity:
+  Description: Disallows methods with a cyclomatic complexity higher than `MaxComplexity`
+  MaxComplexity: 10
+  Excluded:
+  - src/ext/http/cookie.cr
+  Enabled: true
+  Severity: Convention
+
+Style/NegatedConditionsInUnless:
+  Description: Disallows negated conditions in unless
+  Excluded:
+  - src/ext/http/cookie.cr
+  Enabled: true
+  Severity: Convention

--- a/spec/integration/cookies_spec.cr
+++ b/spec/integration/cookies_spec.cr
@@ -9,6 +9,12 @@ describe Crest do
         (response.cookies).should eq({"k1" => "v1", "k2" => "v2"})
       end
 
+      it "should set cookies with nested params" do
+        response = Crest::Request.execute(:get, "#{TEST_SERVER_URL}", cookies: {"k1" => {"kk1" => "v1"}})
+        (response.status_code).should eq(200)
+        (response.cookies).should eq({"k1[kk1]" => "v1"})
+      end
+
       it "should set cookies in the block" do
         request = Crest::Request.new(:get, TEST_SERVER_URL, cookies: {"k1" => "v1"}) do |req|
           req.cookies["k2"] = "v2"

--- a/src/crest.cr
+++ b/src/crest.cr
@@ -4,6 +4,7 @@ require "base64"
 require "http-client-digest_auth"
 require "http_proxy"
 require "./ext/http/client"
+require "./ext/http/cookie"
 
 # This module's static methods are the entry point for using the Crest client.
 #

--- a/src/crest/request.cr
+++ b/src/crest/request.cr
@@ -291,6 +291,8 @@ module Crest
 
     # Adds "Cookie" headers for the cookies in this collection to the @header instance and returns it
     private def set_cookies!(cookies) : HTTP::Headers
+      cookies = Crest::ParamsEncoder.flatten_params(cookies)
+
       cookies.each do |k, v|
         @cookies << HTTP::Cookie.new(k.to_s, v.to_s)
       end

--- a/src/ext/http/cookie.cr
+++ b/src/ext/http/cookie.cr
@@ -1,0 +1,18 @@
+# https://github.com/crystal-lang/crystal/issues/10983
+module HTTP
+  class Cookie
+    private def validate_name(name)
+      raise IO::Error.new("Invalid cookie name") if name.empty?
+      name.each_byte do |byte|
+        # valid characters for cookie-name per https://tools.ietf.org/html/rfc6265#section-4.1.1
+        # and https://tools.ietf.org/html/rfc2616#section-2.2
+        # "!#$%&'*+-.0123456789ABCDEFGHIJKLMNOPQRSTUWVXYZ^_`abcdefghijklmnopqrstuvwxyz|~"
+        #
+        # + Allows "[" and "]" in the cookies name
+        unless (0x21...0x7f).includes?(byte) && byte != 0x22 && byte != 0x28 && byte != 0x29 && byte != 0x2c && byte != 0x2f && !(0x3a..0x40).includes?(byte) && byte != 0x5c && byte != 0x7b && byte != 0x7d
+          raise IO::Error.new("Invalid cookie name")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
monkey-patch HTTP::Cookie to allow '[' and ']' in a cookie name