### PR TITLE
Support raw string query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Optional parameters:
 - `:form` - a hash containing form data (or a raw string)
 - `:headers` - a hash containing the request headers
 - `:cookies` - a hash containing the request cookies
-- `:params` - a hash that represent query params - a string separated from the preceding part by a question mark (`?`) and a sequence of attribute–value pairs separated by a delimiter (`&`)
+- `:params` - a hash that represent query params (or a raw string) - a string separated from the preceding part by a question mark (`?`) and a sequence of attribute–value pairs separated by a delimiter (`&`)
 - `auth` - access authentication method `basic` or `digest` (default to `basic`)
 - `:user` and `:password` - for authentication
 - `:tls` - client certificates, you can pass in a custom `OpenSSL::SSL::Context::Client` (default to `nil`)

--- a/spec/unit/request_spec.cr
+++ b/spec/unit/request_spec.cr
@@ -31,10 +31,24 @@ describe Crest::Request do
       (request.form_data).should eq(nil)
     end
 
+    it "initialize the GET request with string params" do
+      request = Crest::Request.new(:get, "http://localhost", params: "foo=hello+world&bar=456")
+      (request.method).should eq("GET")
+      (request.url).should eq("http://localhost?foo=hello+world&bar=456")
+      (request.form_data).should eq(nil)
+    end
+
     it "initialize the GET request with params" do
       request = Crest::Request.new(:get, "http://localhost", params: {:foo => "hello world", :bar => 456})
       (request.method).should eq("GET")
       (request.url).should eq("http://localhost?foo=hello+world&bar=456")
+      (request.form_data).should eq(nil)
+    end
+
+    it "initialize the GET request with string params and existing params in url" do
+      request = Crest::Request.new(:get, "http://localhost?json", params: "key=123")
+      (request.method).should eq("GET")
+      (request.url).should eq("http://localhost?json&key=123")
       (request.form_data).should eq(nil)
     end
 

--- a/src/crest/request.cr
+++ b/src/crest/request.cr
@@ -35,7 +35,7 @@ module Crest
   # - `headers` a hash containing the request headers
   # - `cookies` a hash containing the request cookies
   # - `form` a hash containing form data (or a raw string)
-  # - `params` a hash that represent query params - a string separated from the preceding part by a question mark (?)
+  # - `params` a hash that represent query params (or a raw string) - a string separated from the preceding part by a question mark (?)
   #    and a sequence of attribute–value pairs separated by a delimiter (&).
   # - `auth` access authentication method `basic` or `digest` (default to `basic`)
   # - `user` and `password` for authentication
@@ -358,8 +358,8 @@ module Crest
     end
 
     # Extract the query parameters and append them to the `url`
-    private def process_url_params(params) : String
-      query_string = Crest::ParamsEncoder.encode(params)
+    private def process_url_params(params : Hash | String) : String
+      query_string = params.is_a?(String) ? params : Crest::ParamsEncoder.encode(params)
 
       if url.includes?("?")
         "&" + query_string


### PR DESCRIPTION
Support raw string query params, so that query parameter encoding could be handled by user.

This is to make it easy to support various parameter encoding rules specified by the OpenAPI specification [here](https://spec.openapis.org/oas/latest.html#style-examples).

For example, Crest::ParamsEncoder.encode({"a" => ["one", "two", "three"]}) gives `a[]=one&a[]=two&a[]=three`.
But according to the spec, it should be `a=one&a=two&a=three`

Twilio is one of the vendors that require array query params NOT to have square brackets.

Alternatively, this could be supported by an option flag in the Crest::ParamsEncoder that controls whether to add the square brackets or not.