### PR TITLE
add multipart parameter to request

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Optional parameters:
 - `:tls` - client certificates, you can pass in a custom `OpenSSL::SSL::Context::Client` (default to `nil`)
 - `:p_addr`, `:p_port`, `:p_user`, and `:p_pass` - specify a per-request proxy by passing these parameters
 - `:json` - make a JSON request with the appropriate HTTP headers (default to `false`)
+- `:multipart` make a multipart request with the appropriate HTTP headers even if not sending a file (default to `false`)
 - `:user_agent` - set "User-Agent" HTTP header (default to `Crest::USER_AGENT`)
 - `:max_redirects` - maximum number of redirects (default to 10)
 - `:logging` - enable logging (default to `false`)

--- a/spec/unit/request_spec.cr
+++ b/spec/unit/request_spec.cr
@@ -103,6 +103,14 @@ describe Crest::Request do
       (request.form_data.to_s).should contain("form-data; name=\"file\"; filename=")
     end
 
+    it "initialize the POST request with multipart if the multipart parameter is provided" do
+      request = Crest::Request.new(:post, "http://localhost", form: {:foo => "bar"}, multipart: true)
+      (request.method).should eq("POST")
+      (request.url).should eq("http://localhost")
+      (request.headers["Content-Type"]).should contain("multipart/form-data; boundary=")
+      (request.form_data.to_s).should contain("form-data; name=\"foo\"\r\n\r\nbar\r\n")
+    end
+
     it "do the POST request with nested form" do
       request = Crest::Request.new(:post, "http://localhost", form: {:params1 => "one", :nested => {:params2 => "two"}})
       (request.headers["Content-Type"]).should eq("application/x-www-form-urlencoded")


### PR DESCRIPTION
There is currently no option of sending a POST request to an API that is expecting a content-type of 'multipart/form-data' without a file. Some APIs will still expect this content-type but the file itself will be optional so does not always need to be sent.

This pull requests adds an optional parameter of 'multipart' which is used in the form_class conditional to select the Crest::DataForm form. The json parameter has higher precedence to the multipart parameter if both are given with the default still being URLencodedform.