### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ With Proxy:
 ```crystal
 resource = Crest::Resource.new(
   "http://httpbin.org/get",
-  p_host: "localhost",
+  p_addr: "localhost",
   p_port: 3128
 )
 ```


### PR DESCRIPTION
Hi @mamantoha 

I was reading the README.md and I think `p_host` is a typo. 
I searched the directory for `p_host` and found no matches other than README.md.
Thank you for maintaining a great library in difficult social situations.
